### PR TITLE
Fix recent regressions and make the example work again.

### DIFF
--- a/docker-make.py
+++ b/docker-make.py
@@ -40,7 +40,7 @@ class DockerMaker(object):
 
         self._sources = set()
         self.makefile_path = makefile
-        self.img_defs = self.parse_yaml(self.makefile_path)
+        self.img_defs = self.parse_yaml(self.makefile_path.name)
         self.all_targets = self.img_defs.pop('_ALL_', None)
 
         # Connect to docker daemon if necessary
@@ -68,12 +68,11 @@ class DockerMaker(object):
         self.no_cache = no_cache
 
         self.buildargs = {}
-        fname = buildargs
+        if buildargs:
         print 'READING %s' % os.path.expanduser(fname)
+            print 'READING %s' % fname
         with open(fname, 'r') as yaml_file:
             self.buildargs = yaml.load(yaml_file)
-        #
-        print 'buildargs dict `%s`' % self.buildargs
 
     def parse_yaml(self, filename):
         fname = os.path.expanduser(filename)
@@ -147,7 +146,6 @@ class DockerMaker(object):
         else:
             build_args['fileobj'] = StringIO(unicode(dockerfile))
 
-        #
         build_args['buildargs'] = self.buildargs
 
         # start the build
@@ -197,8 +195,8 @@ class DockerMaker(object):
 
             step.images.append(d)
             from_dockerfile = dep_definition.get('import_dockerfile', 'Dockerfile')
-            from_dockerfile = os.path.join(step.build_dir, from_dockerfile)
-            # print('from_dockerfile: %s' % from_dockerfile)
+            if step.build_dir is not None:
+                from_dockerfile = os.path.join(step.build_dir, from_dockerfile)
             if os.path.exists(from_dockerfile):
                 try:
                     with open(from_dockerfile, 'r') as import_dockerfile:
@@ -457,6 +455,7 @@ def make_arg_parser():
     bo.add_argument('TARGETS', nargs="*",
                     help='Docker images to build as specified in the YAML file')
     bo.add_argument('-f', '--makefile',
+                    type=argparse.FileType('r'),
                     default='DockerMake.yml',
                     help='YAML file containing build instructions')
     bo.add_argument('-a', '--all', action='store_true',
@@ -469,7 +468,7 @@ def make_arg_parser():
                     help="Name for custom docker images (requires --requires)")
 
     bo.add_argument('-b', '--buildargs',
-                    default='buildargs.yml',
+                    type=argparse.FileType('r'),
                     help="YAML file containing build args")
 
     df = parser.add_argument_group('Dockerfiles')

--- a/docker-make.py
+++ b/docker-make.py
@@ -69,10 +69,8 @@ class DockerMaker(object):
 
         self.buildargs = {}
         if buildargs:
-        print 'READING %s' % os.path.expanduser(fname)
-            print 'READING %s' % fname
-        with open(fname, 'r') as yaml_file:
-            self.buildargs = yaml.load(yaml_file)
+            print 'READING %s' % buildargs.name
+            self.buildargs = yaml.load(buildargs)
 
     def parse_yaml(self, filename):
         fname = os.path.expanduser(filename)


### PR DESCRIPTION
* Make the buildargs argument optional
* Fix: don't prefix from_dockerfile with step.build_dir if none was present
* Use argparse.FileType() to ensure ArgumentParser flags unreadable files
** Let the shell expand ~ in paths on the command line
+ Remove debug output