### PR TITLE
Issue #16 - Fix broken push-to-registry option by correcting typo in …

### DIFF
--- a/dockermake/utils.py
+++ b/dockermake/utils.py
@@ -110,7 +110,7 @@ def build_targets(args, defs, targets):
             b.write_dockerfile(args.dockerfile_dir)
 
         built.append(b.targetname)
-        if args.push_to_registry and not args.nobuild:
+        if args.push_to_registry and not args.no_build:
             success, w = push(client, b.targetname)
             warnings.extend(w)
             if not success:


### PR DESCRIPTION
…dockermake/utils.py build_targets(). 'args.nobuild' was referenced instead of 'args.no_build'

Signed-off-by: Aaron Curley <accwebs@gmail.com>