### PR TITLE
Cache resolution from images with the same name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ docker_makefiles
 Dockerfile.fail
 _docker_make_tmp
 dockerfile.fail
+MANIFEST
 
 # IntelliJ project files
 .idea

--- a/dockermake/__main__.py
+++ b/dockermake/__main__.py
@@ -25,15 +25,16 @@ from .imagedefs import ImageDefs
 from . import errors
 
 
+RED_ERROR = termcolor.colored('FATAL ERROR:', 'red')
+
 def main():
     parser = cli.make_arg_parser()
     args = parser.parse_args()
 
     try:
         run(args)
-    except errors.UserException as exc:
-        red_error = termcolor.colored('FATAL ERROR:', 'red')
-        print(red_error, exc.args[0], file=sys.stderr)
+    except (errors.UserException, errors.BuildError) as exc:
+        print(RED_ERROR, exc.args[0], file=sys.stderr)
         sys.exit(exc.CODE)
 
 

--- a/dockermake/__main__.py
+++ b/dockermake/__main__.py
@@ -31,11 +31,14 @@ def main():
     parser = cli.make_arg_parser()
     args = parser.parse_args()
 
-    try:
+    if args.debug:
         run(args)
-    except (errors.UserException, errors.BuildError) as exc:
-        print(RED_ERROR, exc.args[0], file=sys.stderr)
-        sys.exit(exc.CODE)
+    else:
+        try:
+            run(args)
+        except (errors.UserException, errors.BuildError) as exc:
+            print(RED_ERROR, exc.args[0], file=sys.stderr)
+            sys.exit(exc.CODE)
 
 
 def _runargs(argstring):

--- a/dockermake/builds.py
+++ b/dockermake/builds.py
@@ -120,7 +120,7 @@ class BuildTarget(object):
 
     def _get_stack_key(self, istep):
         names = [self.from_image]
-        for i in xrange(istep+1):
+        for i in range(istep+1):
             step = self.steps[i]
             if isinstance(step, FileCopyStep):
                 continue

--- a/dockermake/builds.py
+++ b/dockermake/builds.py
@@ -43,6 +43,8 @@ class BuildTarget(object):
         self.from_image = from_image
 
     def write_dockerfile(self, output_dir):
+        """ Used only to write a Dockerfile that will NOT be built by docker-make
+        """
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 

--- a/dockermake/cli.py
+++ b/dockermake/cli.py
@@ -82,6 +82,7 @@ def make_arg_parser():
                     help="Print version and exit.")
     hh.add_argument('--help-yaml', action='store_true',
                     help="Print summary of YAML file format and exit.")
+    hh.add_argument('--debug', action='store_true')
 
     return parser
 

--- a/dockermake/cli.py
+++ b/dockermake/cli.py
@@ -47,6 +47,18 @@ def make_arg_parser():
     ca = parser.add_argument_group('Image caching')
     ca.add_argument('--pull', action='store_true',
                     help='Always try to pull updated FROM images')
+    ca.add_argument('--cache-repo',
+                    help='Repository to use for cached images. This allows you to invoke the '
+                    '`docker build --build-from` option for each image.'
+                    'For instance, running '
+                    '`docker-make foo bar --cache-repo docker.io/cache` will use '
+                    'docker.io/cache/foo as a cache for `foo` and docker.io/cache/bar as a cache'
+                    'for `bar`.',
+                    default='')
+    ca.add_argument('--cache-tag',
+                    help='Tag to use for cached images; '
+                         'can be used with the --cache-repo option (see above).',
+                    default='')
     ca.add_argument('--no-cache', action='store_true',
                     help="Rebuild every layer")
     ca.add_argument('--bust-cache', action='append',
@@ -60,8 +72,10 @@ def make_arg_parser():
                     help="Prepend this repository to all built images, e.g.\n"
                          "`docker-make hello-world -u quay.io/elvis` will tag the image "
                          "as `quay.io/elvis/hello-world`. You can add a ':' to the end to "
-                         "image names into tags:\n `docker-make -u quay.io/elvis/repo: hello-world` "
-                         "will create the image in the elvis repository: quay.io/elvis/repo:hello-world")
+                         "image names into tags:\n "
+                         "`docker-make -u quay.io/elvis/repo: hello-world` "
+                         "will create the "
+                         "image in the elvis repository: quay.io/elvis/repo:hello-world")
     rt.add_argument('--tag', '-t', type=str,
                     help='Tag all built images with this tag. If image names are ALREADY tags (i.e.,'
                          ' your repo name ends in a ":"), this will append the tag name with a dash. '

--- a/dockermake/errors.py
+++ b/dockermake/errors.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # Copyright 2017 Autodesk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from io import StringIO
+import pprint
+from termcolor import cprint
 
 class UserException(Exception):
     """
@@ -68,3 +72,20 @@ class ParsingFailure(UserException):
 
 class MultipleIgnoreError(UserException):
     CODE = 51
+
+
+class BuildError(Exception):
+    CODE = 200
+
+    def __init__(self, dockerfile, item, build_args):
+        with open('dockerfile.fail', 'w') as dff:
+            print(dockerfile, file=dff)
+        with StringIO() as stream:
+            cprint('Docker build failure', 'red', attrs=['bold'], file=stream)
+            print(u'\n   -------- Docker daemon output --------', file=stream)
+            pprint.pprint(item, stream, indent=4)
+            print(u'   -------- Arguments to client.build --------', file=stream)
+            pprint.pprint(build_args, stream, indent=4)
+            print(u'This dockerfile was written to dockerfile.fail', file=stream)
+            stream.seek(0)
+            super(BuildError, self).__init__(stream.read())

--- a/dockermake/imagedefs.py
+++ b/dockermake/imagedefs.py
@@ -93,6 +93,20 @@ class ImageDefs(object):
                 if key in defn:
                     defn[key] = _get_abspath(pathroot, defn[key])
 
+            if 'copy_from' in defn:
+                if not isinstance(defn['copy_from'], dict):
+                    raise errors.ParsingFailure((
+                            'Syntax error in file "%s": \n' +
+                            'The "copy_from" field in image definition "%s" is not \n' 
+                            'a key:value list.') % (ymlfilepath, imagename))
+                for otherimg, value in defn.get('copy_from', {}).items():
+                    if not isinstance(value, dict):
+                        raise errors.ParsingFailure((
+                            'Syntax error in field:\n'
+                            '     %s . copy_from . %s\nin file "%s". \n'
+                            'All entries must be of the form "sourcepath: destpath"')%
+                                 (imagename, otherimg, ymlfilepath))
+
             # save the file path for logging
             defn['_sourcefile'] = relpath
 

--- a/dockermake/imagedefs.py
+++ b/dockermake/imagedefs.py
@@ -43,13 +43,12 @@ class ImageDefs(object):
         print('Copy cache directory: %s' % staging.TMPDIR)
         try:
             self.ymldefs = self.parse_yaml(self.makefile_path)
+        except errors.UserException:
+            raise
         except Exception as exc:
-            if isinstance(exc, errors.UserException):
-                raise
-            else:
-                raise errors.ParsingFailure('Failed to read file %s:\n' % self.makefile_path +
-                                            str(exc))
-        self.all_targets = self.ymldefs.pop('_ALL_', None)
+            raise errors.ParsingFailure('Failed to read file %s:\n' % self.makefile_path +
+                                        str(exc))
+        self.all_targets = self.ymldefs.pop('_ALL_', [])
         self._external_dockerfiles = {}
 
     def parse_yaml(self, filename):

--- a/dockermake/imagedefs.py
+++ b/dockermake/imagedefs.py
@@ -135,9 +135,9 @@ class ImageDefs(object):
         """
         from_image = self.get_external_base_image(image)
         if cache_repo or cache_tag:
-            from_cache = utils.generate_name(image, cache_repo, cache_tag)
+            cache_from = utils.generate_name(image, cache_repo, cache_tag)
         else:
-            from_cache = None
+            cache_from = None
         if from_image is None:
             raise errors.NoBaseError("No base image found in %s's dependencies" % image)
         if isinstance(from_image, ExternalDockerfile):
@@ -161,7 +161,7 @@ class ImageDefs(object):
                     dockermake.step.BuildStep(
                             base_name, base_image, self.ymldefs[base_name],
                             buildname, bust_cache=base_name in rebuilds,
-                            build_first=build_first, from_cache=from_cache))
+                            build_first=build_first, cache_from=cache_from))
 
             base_image = buildname
             build_first = None
@@ -176,7 +176,7 @@ class ImageDefs(object):
                                     sourceimage, sourcepath, destpath,
                                     base_name, base_image, self.ymldefs[base_name],
                                     buildname, bust_cache=base_name in rebuilds,
-                                    build_first=build_first, from_cache=from_cache))
+                                    build_first=build_first, cache_from=cache_from))
                     base_image = buildname
 
         sourcebuilds = [self.generate_build(img, img, cache_repo=cache_repo, cache_tag=cache_tag)

--- a/dockermake/staging.py
+++ b/dockermake/staging.py
@@ -47,13 +47,15 @@ class StagedFile(object):
         sourceimage (str): name of the image to copy from
         sourcepath (str): path in the source image
         destpath (str): path in the target image
+        from_cache (str or list): use this(these) image(s) to resolve build cache
     """
-    def __init__(self, sourceimage, sourcepath, destpath):
+    def __init__(self, sourceimage, sourcepath, destpath, from_cache=None):
         self.sourceimage = sourceimage
         self.sourcepath = sourcepath
         self.destpath = destpath
         self._sourceobj = None
         self._cachedir = None
+        self.from_cache = from_cache
 
     def stage(self, startimage, newimage):
         """ Copies the file from source to target
@@ -103,6 +105,9 @@ class StagedFile(object):
         buildargs = dict(path=cachedir,
                          tag=newimage,
                          decode=True)
+
+        if self.from_cache:
+            buildargs['from_cache'] = self.from_cache
 
         # Build and show logs
         stream = client.api.build(**buildargs)

--- a/dockermake/staging.py
+++ b/dockermake/staging.py
@@ -47,15 +47,15 @@ class StagedFile(object):
         sourceimage (str): name of the image to copy from
         sourcepath (str): path in the source image
         destpath (str): path in the target image
-        from_cache (str or list): use this(these) image(s) to resolve build cache
+        cache_from (str or list): use this(these) image(s) to resolve build cache
     """
-    def __init__(self, sourceimage, sourcepath, destpath, from_cache=None):
+    def __init__(self, sourceimage, sourcepath, destpath, cache_from=None):
         self.sourceimage = sourceimage
         self.sourcepath = sourcepath
         self.destpath = destpath
         self._sourceobj = None
         self._cachedir = None
-        self.from_cache = from_cache
+        self.cache_from = cache_from
 
     def stage(self, startimage, newimage):
         """ Copies the file from source to target
@@ -106,8 +106,8 @@ class StagedFile(object):
                          tag=newimage,
                          decode=True)
 
-        if self.from_cache:
-            buildargs['from_cache'] = self.from_cache
+        if self.cache_from:
+            buildargs['cache_from'] = self.cache_from
 
         # Build and show logs
         stream = client.api.build(**buildargs)

--- a/dockermake/staging.py
+++ b/dockermake/staging.py
@@ -62,8 +62,6 @@ class StagedFile(object):
             startimage (str): name of the image to stage these files into
             newimage (str): name of the created image
         """
-        from .step import BuildError
-
         client = utils.get_client()
         cprint('  Copying file from "%s:/%s" \n                 to "%s://%s/"'
                % (self.sourceimage, self.sourcepath, startimage, self.destpath),
@@ -111,7 +109,7 @@ class StagedFile(object):
         try:
             utils.stream_docker_logs(stream, newimage)
         except ValueError as e:
-            raise BuildError(dockerfile, e.args[0], build_args=buildargs)
+            raise errors.BuildError(dockerfile, e.args[0], build_args=buildargs)
 
     def _setcache(self, client):
         if self._sourceobj is None:  # get image and set up cache if necessary

--- a/dockermake/step.py
+++ b/dockermake/step.py
@@ -202,7 +202,7 @@ class FileCopyStep(BuildStep):
     """
     def __init__(self, sourceimage, sourcepath, destpath, *args, **kwargs):
         kwargs.pop('bust_cache', None)
-        super().__init__(*args, **kwargs)
+        super(FileCopyStep, self).__init__(*args, **kwargs)
         self.sourceimage = sourceimage
         self.sourcepath = sourcepath
         self.destpath = destpath

--- a/dockermake/step.py
+++ b/dockermake/step.py
@@ -14,7 +14,6 @@
 from __future__ import print_function
 
 import os
-import pprint
 from io import StringIO, BytesIO
 import sys
 
@@ -136,7 +135,7 @@ class BuildStep(object):
         try:
             utils.stream_docker_logs(stream, self.buildname)
         except ValueError as e:
-            raise BuildError(dockerfile, e.args[0], build_args)
+            raise errors.BuildError(dockerfile, e.args[0], build_args)
 
         # remove the temporary dockerfile
         if tempdir is not None:
@@ -227,16 +226,3 @@ class FileCopyStep(BuildStep):
                 "ADD %s %s" % (os.path.basename(self.sourcepath), self.destpath),
                 '']
 
-
-class BuildError(Exception):
-    def __init__(self, dockerfile, item, build_args):
-        with open('dockerfile.fail', 'w') as dff:
-            print(dockerfile, file=dff)
-        with BytesIO() as stream:
-            print('\n   -------- Docker daemon output --------', file=stream)
-            pprint.pprint(item, stream, indent=4)
-            print('   -------- Arguments to client.build --------', file=stream)
-            pprint.pprint(build_args, stream, indent=4)
-            print('This dockerfile was written to dockerfile.fail', file=stream)
-            stream.seek(0)
-            super(BuildError, self).__init__(stream.read())

--- a/dockermake/step.py
+++ b/dockermake/step.py
@@ -35,11 +35,11 @@ class BuildStep(object):
         img_def (dict): yaml definition of this image
         buildname (str): what to call this image, once built
         bust_cache(bool): never use docker cache for this build step
-        from_cache (str or list): use this(these) image(s) to resolve build cache
+        cache_from (str or list): use this(these) image(s) to resolve build cache
     """
 
     def __init__(self, imagename, baseimage, img_def, buildname,
-                 build_first=None, bust_cache=False, from_cache=None):
+                 build_first=None, bust_cache=False, cache_from=None):
         self.imagename = imagename
         self.baseimage = baseimage
         self.img_def = img_def
@@ -50,10 +50,10 @@ class BuildStep(object):
         self.build_first = build_first
         self.custom_exclude = self._get_ignorefile(img_def)
         self.ignoredefs_file = img_def.get('ignorefile', img_def['_sourcefile'])
-        if from_cache and isinstance(str, from_cache):
-            self.from_cache = [from_cache]
+        if cache_from and isinstance(cache_from, str):
+            self.cache_from = [cache_from]
         else:
-            self.from_cache = from_cache
+            self.cache_from = cache_from
 
     @staticmethod
     def _get_ignorefile(img_def):
@@ -103,8 +103,8 @@ class BuildStep(object):
                           nocache=not usecache,
                           decode=True, rm=True)
 
-        if usecache and self.from_cache:
-            build_args['from_cache'] = self.from_cache
+        if usecache and self.cache_from:
+            build_args['cache_from'] = self.cache_from
 
         if self.build_dir is not None:
             tempdir = self.write_dockerfile(dockerfile)
@@ -198,7 +198,7 @@ class FileCopyStep(BuildStep):
         baseimage (str): base image for this step
         img_def (dict): yaml definition of this image
         buildname (str): what to call this image, once built
-        from_cache (str or list): use this(these) image(s) to resolve build cache
+        cache_from (str or list): use this(these) image(s) to resolve build cache
     """
     def __init__(self, sourceimage, sourcepath, destpath, *args, **kwargs):
         kwargs.pop('bust_cache', None)
@@ -214,7 +214,7 @@ class FileCopyStep(BuildStep):
             hey were applied when BUILDING self.sourceimage
         """
         stage = staging.StagedFile(self.sourceimage, self.sourcepath, self.destpath,
-                                   from_cache=self.from_cache)
+                                   cache_from=self.cache_from)
         stage.stage(self.baseimage, self.buildname)
 
     @property

--- a/dockermake/step.py
+++ b/dockermake/step.py
@@ -42,7 +42,7 @@ class BuildStep(object):
                  build_first=None, bust_cache=False, from_cache=None):
         self.imagename = imagename
         self.baseimage = baseimage
-        self.dockerfile_lines = ['FROM %s\n' % baseimage, img_def.get('build', '')]
+        self.img_def = img_def
         self.buildname = buildname
         self.build_dir = img_def.get('build_directory', None)
         self.bust_cache = bust_cache
@@ -180,6 +180,11 @@ class BuildStep(object):
         image.built = True
         cprint("  Finished building Dockerfile at %s" % image.path, 'green')
 
+    @property
+    def dockerfile_lines(self):
+        return ['FROM %s\n' % self.baseimage,
+                self.img_def.get('build', '')]
+
 
 class FileCopyStep(BuildStep):
     """
@@ -214,6 +219,9 @@ class FileCopyStep(BuildStep):
 
     @property
     def dockerfile_lines(self):
+        """
+        Used only when printing dockerfiles, not for building
+        """
         w1 = colored(
                 'WARNING: this build includes files that are built in other images!!! The generated'
                 '\n         Dockerfile must be built in a directory that contains'

--- a/dockermake/step.py
+++ b/dockermake/step.py
@@ -209,6 +209,24 @@ class FileCopyStep(BuildStep):
         stage = staging.StagedFile(self.sourceimage, self.sourcepath, self.destpath)
         stage.stage(self.base_image, self.buildname)
 
+    @property
+    def dockerfile_lines(self):
+        w1 = colored(
+                'WARNING: this build includes files that are built in other images!!! The generated'
+                '\n         Dockerfile must be built in a directory that contains'
+                ' the file/directory:',
+                'red', attrs=['bold'])
+        w2 = colored('         ' + self.sourcepath, 'red')
+        w3 = (colored('         from image ', 'red')
+              + colored(self.sourcepath, 'blue', attrs=['bold']))
+        print('\n'.join((w1, w2, w3)))
+        return ["",
+                "# Warning: the file \"%s\" from the image \"%s\""
+                " must be present in this build context!!" %
+                (self.sourcepath, self.sourceimage),
+                "ADD %s %s" % (os.path.basename(self.sourcepath), self.destpath),
+                '']
+
 
 class BuildError(Exception):
     def __init__(self, dockerfile, item, build_args):

--- a/dockermake/step.py
+++ b/dockermake/step.py
@@ -18,7 +18,7 @@ from io import StringIO, BytesIO
 import sys
 
 from termcolor import cprint, colored
-import docker.utils
+import docker.utils, docker.errors
 
 from . import utils
 from . import staging
@@ -134,8 +134,8 @@ class BuildStep(object):
         stream = client.build(**build_args)
         try:
             utils.stream_docker_logs(stream, self.buildname)
-        except ValueError as e:
-            raise errors.BuildError(dockerfile, e.args[0], build_args)
+        except (ValueError, docker.errors.APIError) as e:
+            raise errors.BuildError(dockerfile, str(e), build_args)
 
         # remove the temporary dockerfile
         if tempdir is not None:

--- a/dockermake/utils.py
+++ b/dockermake/utils.py
@@ -15,7 +15,6 @@ from __future__ import print_function
 
 import collections
 import os
-import sys
 import textwrap
 
 import yaml
@@ -50,8 +49,8 @@ def list_image_defs(args, defs):
     return
 
 
-def generate_name(image, args):
-    repo_base = args.repository
+def generate_name(image, repo, tag):
+    repo_base = repo
 
     if repo_base is not None:
         if repo_base[-1] not in ':/':
@@ -60,11 +59,11 @@ def generate_name(image, args):
     else:
         repo_name = image
 
-    if args.tag:
+    if tag:
         if ':' in repo_name:
-            repo_name += '-'+args.tag
+            repo_name += '-'+tag
         else:
-            repo_name += ':'+args.tag
+            repo_name += ':'+tag
 
     return repo_name
 
@@ -109,7 +108,11 @@ def build_targets(args, defs, targets):
         print("\nREGISTRY LOGIN SUCCESS:",registry)
 
     built, warnings = [], []
-    builders = [defs.generate_build(t, generate_name(t, args), rebuilds=args.bust_cache)
+    builders = [defs.generate_build(t,
+                                    generate_name(t, args.repository, args.tag),
+                                    rebuilds=args.bust_cache,
+                                    cache_repo=args.cache_repo,
+                                    cache_tag=args.cache_tag)
                 for t in targets]
     for b in builders:
         b.build(client,

--- a/test/data/simple.yml
+++ b/test/data/simple.yml
@@ -1,0 +1,4 @@
+simple-target:
+  FROM: python:3.6-slim
+  build: |
+    RUN echo "spam egg foo bar" > /opt/sometext.txt

--- a/test/data/write.yml
+++ b/test/data/write.yml
@@ -1,0 +1,9 @@
+writetarget:
+  FROM: miniconda
+  description: "For testing write capabilities, not meant to be built"
+  copy_from:
+    temp:
+      /b: /c
+
+temp:
+  FROM: blah

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -57,6 +57,7 @@ def test_ignore_directory(img6):
 
 
 def test_dockerfile_write(tmpdir):
+    tmpdir = str(tmpdir)
     run_docker_make('-f data/write.yml -p -n --dockerfile-dir %s writetarget' % tmpdir)
     assert os.path.isfile(os.path.join(tmpdir, 'Dockerfile.writetarget'))
 

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from dockermake.__main__ import _runargs as run_docker_make
 
@@ -48,6 +49,11 @@ img6 = creates_images('target_ignore_directory')
 def test_ignore_directory(img6):
     run_docker_make('-f data/ignores.yml target_ignore_directory')
     _check_files('target_ignore_directory', d=False)
+
+
+def test_dockerfile_write(tmpdir):
+    run_docker_make('-f data/write.yml -p -n --dockerfile-dir %s writetarget' % tmpdir)
+    assert os.path.isfile(os.path.join(tmpdir, 'Dockerfile.writetarget'))
 
 
 def _check_files(img, **present):


### PR DESCRIPTION
Implement --cache-repo and --cache-tag options, so that, when building images `spam` and `eggs` like so:

`docker-make spam eggs --cache-repo foo --cache-tag bar`

We will use the image at `docker.io/foo/spam:bar` as a cache source for `spam` and `docker.io/foo/eggs:bar` as a cache source for `eggs` (see `docker build --cache-from` docs)