### PR TITLE
Add --keep-build-tags flag

### DIFF
--- a/dockermake/cli.py
+++ b/dockermake/cli.py
@@ -66,6 +66,8 @@ def make_arg_parser():
                     'multiple image layers by passing --bust-cache multiple times.')
     ca.add_argument('--clear-copy-cache', '--clear-cache', action='store_true',
                     help="Remove docker-make's cache of files for `copy-from`.")
+    ca.add_argument('--keep-build-tags', action='store_true',
+                    help="Don't untag intermediate build containers when build is complete")
 
     rt = parser.add_argument_group('Repositories and tags')
     rt.add_argument('--repository', '-r', '-u',

--- a/dockermake/utils.py
+++ b/dockermake/utils.py
@@ -119,7 +119,8 @@ def build_targets(args, defs, targets):
         b.build(client,
                 nobuild=args.no_build,
                 usecache=not args.no_cache,
-                pull=args.pull)
+                pull=args.pull,
+                keepbuildtags=args.keep_build_tags)
         if not args.no_build:
             print('  docker-make built:', b.targetname)
 

--- a/test/data/twostep.yml
+++ b/test/data/twostep.yml
@@ -1,0 +1,10 @@
+first:
+  FROM: python:3.6-slim
+  build: |
+    RUN echo 'test' > /opt/test
+
+target-twostep:
+  requires:
+    - first
+  build: |
+    RUN echo 'test2' > /opt/test2

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -107,3 +107,10 @@ def _check_files(img, **present):
             assert_file_content(img, record['path'], record['content'])
 
 
+twostep = creates_images('target-twostep',
+                         'dmkbuild_target-twostep_2',
+                         'dmkbuild_target-twostep_1')
+def test_keep_build_tags(twostep, docker_client):
+    run_docker_make('-f data/twostep.yml target-twostep --keep-build-tags')
+    docker_client.images.get('dmkbuild_target-twostep_1')
+    docker_client.images.get('dmkbuild_target-twostep_2')


### PR DESCRIPTION
This is helpful for debugging, but especially helpful to prevent race conditions when concurrent builds are running